### PR TITLE
rename main->md5hash and changed input method to command line args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,30 @@
 CC = gcc
 CCFLAGS = -Iinc -O2
 
-main.exe: obj/main.o obj/MD5.o
-	$(CC) -o $@ obj/MD5.o obj/main.o $(CCFLAGS)
+# build target to make executable md5 hash command line program
+.PHONY: md5hash
+md5hash: md5hash.exe
+md5hash.exe: obj/md5hash.o obj/MD5.o
+	$(CC) -o $@ obj/MD5.o obj/md5hash.o $(CCFLAGS)
 
-obj/main.o: src/main.c inc/MD5.h ./obj
-	$(CC) -c src/main.c -o $@ $(CCFLAGS)
-
+# build targets for object files
+obj/md5hash.o: src/md5hash.c inc/MD5.h ./obj
+	$(CC) -c src/md5hash.c -o $@ $(CCFLAGS)
 obj/MD5.o: src/MD5.c inc/MD5.h ./obj
 	$(CC) -c src/MD5.c -o $@ $(CCFLAGS)
 
+# build target to create directory for object files
 ./obj:
 	mkdir $@
+
+# build target to delete all files generated while building the executable
+.PHONY: clean
+clean:
+	rmdir obj /s /q
+	del md5hash.exe
+
+# build target to test output executable with Dr Memory
+.PHONY: drmemtest
+drmemtest: src/md5hash.c src/MD5.c
+	$(CC) -static -o md5hash.exe src/md5hash.c src/MD5.c -Iinc
+	drmemory md5hash.exe abcdefghijklmnopqrstuvwxyz

--- a/inc/MD5.h
+++ b/inc/MD5.h
@@ -1,6 +1,8 @@
 #include <Windows.h>
-
 #include <stdint.h>
+
+#ifndef MD5_H
+#define MD5_H
 
 /**
  * Calculates the MD5 hash of an array of characters. 
@@ -9,19 +11,33 @@
  * 
  * Given an array of 8-bit characters, the length of the character string,
  * and the array into which the result should be written, this function
- * will calculate the MD5 Hash of the given string. The string should
- * contain no more than 55 characters, but should be 64-bytes in length
+ * will calculate the MD5 Hash of the given string. The string can be of any
+ * length, but the array holding it should be a multiple of 64-bytes in length
  * to allow the function to add the padding as required by the MD5 hash
- * algorithm to be added to the end of the string.
+ * algorithm to be added to the end of the string (see get_md5_chunk_count()).
  * 
  * See https://en.wikipedia.org/wiki/MD5 for more information.
  * 
- * @param string A 64-byte array of 55 or less characters; bytes after the
- * characters will be modified by this function
+ * @param string A byte array with length that is a multiple of 64 bytes 
+ * containing a string of characters; array will be modified by the function
  * @param string_len Number of characters in the string to be hashed
  * @param hash_result A 16-byte array to hold/return the hash calculation
- * @return Void; hash result is returned into an array provided by caller
  */
 void inplace_md5_sum(uint8_t* string,
                      const uint32_t string_len,
                      uint8_t* hash_result);
+
+/**
+ * Get the number of 512-bit MD5 chunks are needed to hash a string of the
+ * given length in place.
+ * 
+ * Used in conjunction with the inplace MD5 hash function; use this function
+ * to determine how big the character array needs to be to allow the inplace
+ * hash function to add the necessary padding before performing the hash.
+ * 
+ * @param string_len Length of the string to be hashed (in bytes)
+ * @return the number of 64-byte chunks that will be used to perform the hash
+ */
+uint32_t get_md5_chunk_count(uint32_t string_len);
+
+#endif /* MD5_H */

--- a/src/MD5.c
+++ b/src/MD5.c
@@ -139,3 +139,16 @@ void inplace_md5_sum(uint8_t* string,
   return;
 
 }
+
+uint32_t get_md5_chunk_count(uint32_t string_len) {
+
+  // 9 bytes of padding are required, blocks are 64 bytes long
+  uint32_t chunks = (string_len + 9) / 64;
+
+  // must fill out an entire 64 byte block; add another block if
+  // the string plus 9 bytes of padding was not a multiple of 64 bytes
+  chunks = (string_len + 9) % 64 != 0 ? 1 : 0;
+
+  return chunks;
+
+}

--- a/src/md5hash.c
+++ b/src/md5hash.c
@@ -1,12 +1,10 @@
 #include <Windows.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdio.h>
 
 #include "MD5.h"  // function to perform MD5 hash on string
-
-#define MAX_CHUNKS 1000
-#define MAX_STRING_LENGTH MAX_CHUNKS*64-9
 
 /**
  * Convert 128-bit MD5 hash result to a 32-character hexadecimal string.
@@ -37,19 +35,18 @@ void get_input(char* buffer, size_t max_length);
 
 int main(int argc, char* argv[]) {
 
-  // string to be hashed
-  uint8_t a_string[64 * MAX_CHUNKS];
+  // if an invalid number of arguments are given, print usage instructions
+  if (argc != 2) {
+    puts("Usage: ./md5hash.exe {string-to-hash}");
+    return 1;
+  }
 
-  // prompt the user to enter a string
-  printf(
-    "Enter a string of no more than %d characters to be hashed: ",
-    MAX_STRING_LENGTH
-  );
-  fflush(stdout);
+  // figure out how many md5 512-bit blocks are needed to perform the hash
+  uint32_t chunk_count = get_md5_chunk_count(strlen(argv[1]));
 
-  // get user input; max string len does not include null terminating character
-  // so add one, to max length to create room for that character
-  get_input(a_string, MAX_STRING_LENGTH + 1);
+  // create an array to hold the string to be hashed (plus padding)
+  uint8_t *a_string = malloc(chunk_count * 64 * sizeof(uint8_t));
+  strcpy((char*) a_string, argv[1]);
 
   // get the length of the inputted string
   uint32_t string_len = strlen((char*) a_string);
@@ -69,11 +66,9 @@ int main(int argc, char* argv[]) {
   // replace null terminating character which is removed by the hash function
   a_string[string_len] = 0x00;
 
-  printf(
-    "The result of the hash of %s is %s.",
-    (char*) a_string, 
-    hash_result_string
-  );
+  printf("%s is the hash of \"%s\"", hash_result_string, (char*) a_string);
+
+  free(a_string);
 
 }
 


### PR DESCRIPTION
All changes:
-added build targets to Makefile for memory testing with Dr Memory and clean to remove build files/dirs
-updated comments on md5 hashing function to refect prior change to allow any sized string
-updated main.c/main.exe to md5hash.c/md5hash.exe and input string is provided via command line argument now
-added utility function to md5 hash function to assist with string array creation for inplace md5 hash function